### PR TITLE
Restore Polaris translations with JSON import attributes

### DIFF
--- a/app/routes/app.jsx
+++ b/app/routes/app.jsx
@@ -3,10 +3,7 @@ import { boundary } from "@shopify/shopify-app-remix/server";
 import { AppProvider as RemixAppProvider } from "@shopify/shopify-app-remix/react";
 import { NavMenu } from "@shopify/app-bridge-react";
 import { authenticate } from "../shopify.server";
-
-import { AppProvider as PolarisAppProvider } from "@shopify/polaris";
-import enTranslations from "@shopify/polaris/locales/en.json";
-import "@shopify/polaris/build/esm/styles.css";
+import polarisTranslations from "@shopify/polaris/locales/en.json" with { type: "json" };
 
 export const loader = async ({ request }) => {
   await authenticate.admin(request);
@@ -17,15 +14,17 @@ export default function App() {
   const { apiKey } = useLoaderData();
 
   return (
-    <RemixAppProvider isEmbeddedApp apiKey={apiKey}>
-      <PolarisAppProvider i18n={enTranslations}>
-        <NavMenu>
-          <a href="/app">🏠 Home</a>
-          <a href="/app/additional">📄 Additional Page</a>
-          <a href="/app/test-api">🧪 Test Page</a>
-        </NavMenu>
-        <Outlet />
-      </PolarisAppProvider>
+    <RemixAppProvider
+      isEmbeddedApp
+      apiKey={apiKey}
+      i18n={polarisTranslations}
+    >
+      <NavMenu>
+        <a href="/app">🏠 Home</a>
+        <a href="/app/additional">📄 Additional Page</a>
+        <a href="/app/test-api">🧪 Test Page</a>
+      </NavMenu>
+      <Outlet />
     </RemixAppProvider>
   );
 }

--- a/app/routes/auth.login/route.jsx
+++ b/app/routes/auth.login/route.jsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { Form, useActionData, useLoaderData } from "@remix-run/react";
 import {
-  AppProvider as PolarisAppProvider,
   Button,
   Card,
   FormLayout,
@@ -9,17 +8,18 @@ import {
   Text,
   TextField,
 } from "@shopify/polaris";
-import polarisTranslations from "@shopify/polaris/locales/en.json";
 import polarisStyles from "@shopify/polaris/build/esm/styles.css?url";
+import { AppProvider as RemixAppProvider } from "@shopify/shopify-app-remix/react";
 import { login } from "../../shopify.server";
 import { loginErrorMessage } from "./error.server";
+import polarisTranslations from "@shopify/polaris/locales/en.json" with { type: "json" };
 
 export const links = () => [{ rel: "stylesheet", href: polarisStyles }];
 
 export const loader = async ({ request }) => {
   const errors = loginErrorMessage(await login(request));
 
-  return { errors, polarisTranslations };
+  return { errors };
 };
 
 export const action = async ({ request }) => {
@@ -37,7 +37,7 @@ export default function Auth() {
   const { errors } = actionData || loaderData;
 
   return (
-    <PolarisAppProvider i18n={loaderData.polarisTranslations}>
+    <RemixAppProvider isEmbeddedApp={false} i18n={polarisTranslations}>
       <Page>
         <Card>
           <Form method="post">
@@ -60,6 +60,6 @@ export default function Auth() {
           </Form>
         </Card>
       </Page>
-    </PolarisAppProvider>
+    </RemixAppProvider>
   );
 }


### PR DESCRIPTION
## Summary
- load Polaris English translations via JSON import attributes and feed them into the Remix AppProvider so embedded UI components render reliably
- provide the same Remix AppProvider i18n configuration for the standalone auth login route to keep Polaris widgets translated

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3dafc98cc832b8529667ddd9b8523